### PR TITLE
refactor: use dotenv to import cookies

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,7 +13,7 @@
 > 
 1. `yarn`或者`npm install`安装node依赖
 2. 安装yt-dlp [文档](https://github.com/yt-dlp/yt-dlp#installation)
-3. 提供cookies：编辑config.js或设置`BILIBILI_COOKIE`环境变量
+3. 提供cookies：通过 .env 提供或设置`BILIBILI_COOKIE`环境变量
 4. ./u2bili.sh \<url\>
 
 <details>
@@ -21,7 +21,20 @@
     
 登录后F12,Application(应用程序)面板，选择cookie进行查看。
 ![Cookie](docs/cookie.jpg)
-填写[config.js](config.js)最后4个参数或设置`BILIBILI_COOKIE`环境变量
+以下方法选择一个即可：
+
+- 创建文件 .env，内容格式如下，填入你的变量值即可
+
+```shell
+DedeUserID: "xxxxxx"
+DedeUserID__ckMd5: "xxxxxx"
+bili_jct: "xxxxxx"
+SESSDATA: "xxxxxx"
+```
+
+注意：虽然 .gitignore 里已经写上了 .env，但还是要提醒一下**一定不要**将 .env 文件 push 到远端，否则有账号被盗的危险。
+
+- 设置`BILIBILI_COOKIE`环境变量
 ```
 BILIBILI_COOKIE环境变量格式如下：
 DedeUserID=XXX;DedeUserID__ckMd5=XXX;bili_jct=XXX;SESSDATA=XXX

--- a/config.js
+++ b/config.js
@@ -1,4 +1,5 @@
 // @ts-check
+import 'dotenv/config'
 
 /**
  *  默认只有Windows系统浏览器可视化, 方便调试和排错
@@ -16,8 +17,8 @@ export const downloadPath = "./downloads/"
  * @type {object}
  */
 export const bilibiliCookies = {
-  DedeUserID: "XXXXXXXXXXXXX",
-  DedeUserID__ckMd5: "XXXXXXXXXXXXX",
-  bili_jct: "XXXXXXXXXXXXX",
-  SESSDATA: "XXXXXXXXXXXXX",
+  DedeUserID: process.env.DedeUserID,
+  DedeUserID__ckMd5: process.env.DedeUserID__ckMd5,
+  bili_jct: process.env.bili_jct,
+  SESSDATA: process.env.SESSDATA,
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "homepage": "https://github.com/ame-yu/u2bili",
   "type": "module",
   "dependencies": {
+    "dotenv": "^16.0.3",
     "playwright": "1.25.2"
   }
 }

--- a/upload.js
+++ b/upload.js
@@ -32,7 +32,7 @@ function getCookies() {
       }
     })
   } else {
-    console.log("从配置文件读取Cookie")
+    console.log("从.env读取Cookie")
     return Object.keys(bilibiliCookies).map((k) => {
       return {
         domain: ".bilibili.com",


### PR DESCRIPTION
### 问题

现在的 cookies 是写在 config.js 里的，由于 config.js 里还有别的配置所以不能在 push 时忽略它，这样就有可能误使 cookies 里的敏感数据被 push 到远端，造成敏感数据泄露。 

### 解决方法

引入 [dotenv](https://github.com/motdotla/dotenv) 依赖，在 .env 文件中配置 cookies，由于 .gitignore 里已经加上了 .env，所以可以一定程度上避免泄露危险。